### PR TITLE
Implements config files

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: ['main', 'develop']
   pull_request:
-    branches: ['main', 'develop']
+    branches: ['main']
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .vscode
 results
 src/main/resources/inputs/synthetic_3k
+src/main/resources/inputs/synthetic_3k_corrupt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ cd pop-analysis
 docker build . -t pop-analysis:latest
 
 # Run image
-docker run -v <path_to_record_file>:/app/<path_to_record_file> -v <path_to_results_dir>:/app/<path_to_results_dir> pop-analysis:latest <path_to_record_file>
+docker run -v <path_to_resources_dir>:/app/<path_to_resources_file> -v <path_to_results_dir>:/app/<path_to_results_dir> pop-analysis:latest <path_to_config_file>
 ```
 
-Note: paths must be absolute, not relative
+Note:
+- Paths must be absolute, not relative
+- Assume filepath of record (defined in config file) is within the resources directory, otherwise this will also have to be mounted separately

--- a/src/main/java/org/example/Analysis.java
+++ b/src/main/java/org/example/Analysis.java
@@ -8,16 +8,17 @@ import java.util.List;
  */
 public class Analysis {
     public static void main(String[] args) throws Exception {
-        Config c = new Config();
-        new File(c.resultsDir+"/tables").mkdirs();
-
-        // TODO: Add error handling for missing arguments
         try {
-            List<Record> records = Parser.getAllLines(args[0], c.recordFormat, c.recordType);
+            Config c = new Config(args[0]);
+            new File(c.getResultsDir()+"/tables").mkdirs();
 
-            FreqTable table = new FreqTable(c.analysisType);
+            // TODO: Add error handling for missing arguments
+
+            List<Record> records = Parser.getAllLines(c.getRecordsFilepath(), c.getRecordFormat(), c.getRecordType());
+
+            FreqTable table = new FreqTable(c.getAnalysisType());
             table.add(records);
-            table.output(c.resultsDir);
+            table.output(c.getResultsDir());
         } catch (Exception e) {
             System.err.println("Error: " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/org/example/Config.java
+++ b/src/main/java/org/example/Config.java
@@ -59,13 +59,25 @@ public class Config {
     
     private void processArgs(List<String> lines, Map<String, BiConsumer<Config, String>> processors) {
         String[] parts;
+        String key;
         String value;
+        BiConsumer<Config, String> processor;
 
         for (String ln : lines) {
             parts = ln.split("=");
+
+            if (parts.length == 1) {
+                throw new IllegalArgumentException("Malformed config line: `" + ln + "`. Expected format: key=value");
+            }
+
+            key = parts[0].trim();
             value = String.join("=", Arrays.copyOfRange(parts, 1, parts.length)).trim();
-            processors.get(parts[0].trim()).accept(this, value);
-            // TODO: Catch invalid args
+
+            if ((processor = processors.get(key)) == null) {
+                throw new IllegalArgumentException("`" + key + "` is not a recognised option");
+            }
+
+            processors.get(key).accept(this, value);
         }
     }
 

--- a/src/main/java/org/example/Config.java
+++ b/src/main/java/org/example/Config.java
@@ -1,16 +1,132 @@
 package org.example;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
 /**
  * Contains configuration options for the pop-analysis program. Default options
  * can be modified within this class and other attributes can be set at runtime
  * using a configuration file. 
  */
 public class Config {
-    // TODO: Include defaults as static here
-    public final String recordFormat = Constants.TD;
-    public final String recordType = Constants.BIRTH;
+    // ---- Default values ----
+    private static final String DEFAULT_RESULTS_DIR = "results";
+    private static final String DEFAULT_ANALYSIS_TYPE = Constants.SURNAME_FREQ;
+    
+    // ---- Required Parameters ----
+    private String recordsFilepath;
+    private String recordType;
+    private String recordFormat;
+
+    // ---- Optional Parameters ----
     // TODO: Make this some form of list to perform multiple operations
-    public final String analysisType = "SURNAME_FREQ";
-    public final String resultsDir = "results";
-    public final String recordsFilepath = "src/main/resources/inputs/synthetic_3k/birth_records.csv";
+    private String analysisType = DEFAULT_ANALYSIS_TYPE;
+    private String resultsDir = DEFAULT_RESULTS_DIR;
+
+    public Config(String recordsFilepath, String recordType, String recordFormat) {
+        this.recordsFilepath = recordsFilepath;
+        this.recordType = recordType;
+        this.recordFormat = recordFormat;
+        
+        validateArgs();
+    }
+
+    public Config(String configFilepath) throws FileNotFoundException, IOException {
+        Map<String, BiConsumer<Config, String>> processors = getProcessors();
+        List<String> lines = ConfigFileParser.getAllLines(configFilepath);
+        processArgs(lines, processors);
+        validateArgs();
+    }
+
+    private Map<String, BiConsumer<Config, String>> getProcessors() {
+        Map<String, BiConsumer<Config, String>> processors = 
+            new HashMap<String, BiConsumer<Config, String>>();
+
+        processors.put(Constants.RECORDS_FILEPATH_KEY, Config::setRecordsFilepath);
+        processors.put(Constants.RECORDS_FORMAT_KEY, Config::setRecordFormat);
+        processors.put(Constants.RECORDS_TYPE_KEY, Config::setRecordType);
+        processors.put(Constants.ANALYSIS_TYPE_KEY, Config::setAnalysisType);
+        processors.put(Constants.RESULTS_FILEPATH_KEY, Config::setResultsDir);
+
+        return processors;
+        
+    }
+    
+    private void processArgs(List<String> lines, Map<String, BiConsumer<Config, String>> processors) {
+        String[] parts;
+        String value;
+
+        for (String ln : lines) {
+            parts = ln.split("=");
+            value = String.join("=", Arrays.copyOfRange(parts, 1, parts.length)).trim();
+            processors.get(parts[0].trim()).accept(this, value);
+            // TODO: Catch invalid args
+        }
+    }
+
+    private void validateArgs() {
+        if (recordsFilepath == null) {
+            throw new IllegalArgumentException("`" + Constants.RECORDS_FILEPATH_KEY + "` is required");
+        }
+        if (recordType == null) {
+            throw new IllegalArgumentException("`" + Constants.RECORDS_FORMAT_KEY + "` is required");
+        }
+        if (recordFormat == null) {
+            throw new IllegalArgumentException("`" + Constants.RECORDS_TYPE_KEY + "` is required");
+        }
+        if (!Arrays.asList(Constants.TYPES).contains(recordType)) {
+            throw new IllegalArgumentException("Unrecognised record type: `" + recordType + "`");
+        }
+        if (!Arrays.asList(Constants.FORMATS).contains(recordFormat)) {
+            throw new IllegalArgumentException("Unrecognised record format: `" + recordFormat + "`");
+        }
+        if (!Arrays.asList(Constants.ANALYSIS_OPS).contains(analysisType)) {
+            throw new IllegalArgumentException("Unrecognised analysis type: `" + analysisType + "`");
+        }
+    }
+
+    public String getRecordType() {
+        return recordType;
+    }
+
+    public void setRecordType(String recordType) {
+        this.recordType = recordType;
+    }
+
+    public String getRecordsFilepath() {
+        return recordsFilepath;
+    }
+
+    public void setRecordsFilepath(String recordsFilepath) {
+        this.recordsFilepath = recordsFilepath;
+    }
+
+    public String getRecordFormat() {
+        return recordFormat;
+    }
+
+    public void setRecordFormat(String recordFormat) {
+        this.recordFormat = recordFormat;
+    }
+
+    public String getAnalysisType() {
+        return analysisType;
+    }
+
+    public void setAnalysisType(String analysisType) {
+        this.analysisType = analysisType;
+    }
+
+    public String getResultsDir() {
+        return resultsDir;
+    }
+
+    public void setResultsDir(String resultsDir) {
+        this.resultsDir = resultsDir;
+    }
 }

--- a/src/main/java/org/example/ConfigFileParser.java
+++ b/src/main/java/org/example/ConfigFileParser.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigFileParser {
+    public static List<String> getAllLines(String configFilepath) throws FileNotFoundException, IOException {
+        List<String> lines = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(configFilepath))) {
+
+            String ln;
+            while ((ln = reader.readLine()) != null) {
+                if (ln.length() != 0 && !ln.startsWith(Constants.COMMENT_INDICATOR)) {
+                    lines.add(ln);
+                }
+            }
+        }
+
+        return lines;
+    }
+}

--- a/src/main/java/org/example/Constants.java
+++ b/src/main/java/org/example/Constants.java
@@ -24,7 +24,7 @@ public class Constants {
     // ---- Config files ----
     public static final String RECORDS_FILEPATH_KEY = "records_location";
     public static final String RECORDS_FORMAT_KEY = "record_format";
-    public static final String RECORDS_TYPE_KEY = "records_type";
+    public static final String RECORDS_TYPE_KEY = "record_type";
     public static final String ANALYSIS_TYPE_KEY = "analysis";
     public static final String RESULTS_FILEPATH_KEY = "results_save_location";
     /** Comment-indicator for config file */

--- a/src/main/java/org/example/Constants.java
+++ b/src/main/java/org/example/Constants.java
@@ -20,4 +20,13 @@ public class Constants {
     public static final String SURNAME_FREQ = "SURNAME_FREQ";
     /** List of permitted analysis operations */
     public static final String[] ANALYSIS_OPS = new String[]{FORENAME_FREQ, SURNAME_FREQ};
+
+    // ---- Config files ----
+    public static final String RECORDS_FILEPATH_KEY = "records_location";
+    public static final String RECORDS_FORMAT_KEY = "record_format";
+    public static final String RECORDS_TYPE_KEY = "records_type";
+    public static final String ANALYSIS_TYPE_KEY = "analysis";
+    public static final String RESULTS_FILEPATH_KEY = "results_save_location";
+    /** Comment-indicator for config file */
+    public static final String COMMENT_INDICATOR = "#";
 }

--- a/src/main/resources/config/config.txt
+++ b/src/main/resources/config/config.txt
@@ -1,0 +1,4 @@
+# Example default config
+
+## Required Parameters
+records_location=./src/main/resources/inputs/synthetic_3k/

--- a/src/main/resources/config/config.txt
+++ b/src/main/resources/config/config.txt
@@ -1,4 +1,6 @@
 # Example default config
 
 ## Required Parameters
-records_location=./src/main/resources/inputs/synthetic_3k/
+records_location = ./src/main/resources/inputs/synthetic_3k/birth_records.csv
+record_format = TD
+record_type = BIRTH


### PR DESCRIPTION
Implements configuration files and corresponding parser. Replaces previous CLI argument of record filepath with configuration file filepath and updates README documentation accordingly. Example configuration file, src/main/resources/config/config.txt, included. Closes #10 
