### PR TITLE
1.2.1 Release: Docs + Github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pop-analysis
 Pop-analysis is a basic deployable containerised application for population data analysis, designed as a test for future population-linkage experiments. The focus of this is to create a portable image which can be easily deployed on a secure system and pointed towards a population dataset, with minimal setup.
 
-For more in-depth information, see [documentation](./docs/index.md).
+For more in-depth information, see [documentation](https://jamesross03.github.io/pop-analysis/).
 
 ## Running Pop-analysis
 Pop-analysis can be run from either a JAR file or a Docker container. Basic instructions for these can be found below, for more detailed instructions (including how to securely load private keys into the application), see the [usage guides](docs/usage/index.md). Additionally to build your own JAR files or docker images from the source code, see the [build guides](docs/build/index.md), and for configuration options, see the [configuration guide](docs/config/index.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
-# Pop-analysis
 Pop-analysis is a basic deployable containerised application for population data analysis, designed as a test for future population-linkage experiments. The focus of this is to create a portable image which can be easily deployed on a secure system and pointed towards a population dataset, with minimal setup.
 
 ## Running Pop-Analysis
 - **[Usage instructions](usage/index.md)** - for instructions on how to install and run the latest pop-analysis releases.
 - **[Build instructions](build/index.md)** - for instructions on how to build JAR files and docker images from the source.
-- **[Configuration instructions](config/index.md) - for a guide to configuring the Pop-analysis application.
+- **[Configuration instructions](config/index.md)** - for a guide to configuring the Pop-analysis application.

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -33,7 +33,7 @@ No config file given as CLI arg
 Expected usage: pop-analysis <config-filepath>
 ```
 
-### 2.1. Installing sample resources
+### 2.2. Installing sample resources
 We will use the sample resources from the [Pop-analysis repository](https://github.com/jamesross03/pop-analysis). To install this, run the following command:
 
 ```sh

--- a/docs/usage/key_insertion.md
+++ b/docs/usage/key_insertion.md
@@ -71,3 +71,5 @@ This feature was developed with a focus on security, avoiding ever having to wri
 2. **Be aware of other users on the machine** - while the above flag ensures records of the container aren't stored after runtime, this method is still susceptible to snooping from other users during execution, either via accessing the docker container logs or through using `proc` or other similar system tools.
 3. **Command history** - be aware that if other users have access to your terminal history, they may be able to find your 'docker run' command and extract your private key. Thus it is recommended to clear your terminal history after use:
     - Running `history -c` to clear your session history is insufficient, you should also delete the persistent cross-session history file for your terminal (location varies depending on terminal, e.g `~/.bash_history` or `~/.zsh_history`).
+
+If you are trust the file system on the machine enough to install your private key and mount the .ssh directory into the container instead (using `-v ~/.ssh:/root/.ssh`), this would a more secure approach.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>pop-analysis</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <name>pop-analysis</name>
 


### PR DESCRIPTION
## Overview
Very small patch, containing documentation fixes and adjustments to line-up with the [Github pages project site](https://jamesross03.github.io/pop-analysis/).

## Changelist
**Documentation:**
- Adds a small note about mounting `.ssh` directory to the key insertion guide.
- Changes link to documentation in `README.md` to point to the pages site not the markdown files.
- Fixes section numbering in Docker build guide.
- Fixes bold formatting error in `docs/index.md`.
- Removes title in `docs/index.md` as Pages adds one anyway.